### PR TITLE
Using table caption (default selection), thead, tfoot

### DIFF
--- a/src/js/table.js
+++ b/src/js/table.js
@@ -15,8 +15,12 @@ Table.prototype = {
     var html = this._html(rows, cols);
 
     this._editor.pasteHTML(
-      '<table class="medium-editor-table" id="medium-editor-table"' +
-      ' width="100%">' +
+      '<table class="medium-editor-table" id="medium-editor-table">' +
+      '<caption>' + getSelectionText(this._doc) + '</caption>' +
+      '<thead>' +
+      this._html(0, cols, 'th') +
+      '</thead>' +
+      '<tfoot><tr><td colspan="' + (parseInt(cols) + 1) +'"></td></tr></tfoot>' +
       '<tbody>' +
       html +
       '</tbody>' +
@@ -31,16 +35,17 @@ Table.prototype = {
     placeCaretAtNode(this._doc, table.querySelector('td'), true);
   },
 
-  _html: function (rows, cols) {
+  _html: function (rows, cols, cellType) {
     var html = '';
     var x;
     var y;
     var text = getSelectionText(this._doc);
+    var cell = (cellType == 'th') ? '<th><br /></th>' : '<td><br /></td>';
 
     for (x = 0; x <= rows; x++) {
       html += '<tr>';
       for (y = 0; y <= cols; y++) {
-        html += '<td>' + (x === 0 && y === 0 ? text : '<br />') + '</td>';
+        html += cell;
       }
       html += '</tr>';
     }

--- a/src/sass/medium-editor-tables.scss
+++ b/src/sass/medium-editor-tables.scss
@@ -39,9 +39,11 @@
   border-collapse: collapse;
   resize: both;
   table-layout: fixed;
+  width: 100%;
 }
 
 .medium-editor-table,
-.medium-editor-table td {
+.medium-editor-table td,
+.medium-editor-table th {
   border: 1px dashed #e3e3e3;
 }


### PR DESCRIPTION
This commit changes the default behaviour for the text selection to be the table's caption. That is, when some text is selected, the selected text now takes part in the table `<caption>`. This is arguably more intuitive as tables should have a caption/title to bring some meaning or at least a reference point to talk about.

The other parts of the commit simply adds the `thead` and `tfoot` sections, where `thead` will provide the meaning for the column headers and `tfoot` for supplemental information.

While all `caption`, `thead` and `tfoot` are optional as far as HTML5 is concerned, they tend to bring / encourage good practices when presenting tabular data.
