### PR TITLE
Change medium-editor dependency to ^5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "start": "open ./demo/index.html"
   },
   "peerDependencies": {
-    "medium-editor": "5.0.0"
+    "medium-editor": "^5.0.0"
   }
 }


### PR DESCRIPTION
medium-editor v5.0.0 is strictly required, but it's not the last available version and can cause conflict when doing a npm update.
