### PR TITLE
fix AMD-style definition

### DIFF
--- a/src/wrappers/start.js
+++ b/src/wrappers/start.js
@@ -3,7 +3,9 @@
   if (typeof module === 'object') {
     module.exports = factory;
   } else if (typeof define === 'function' && define.amd) {
-    define(factory);
+    define(function() {
+        return factory;
+    });
   } else {
     root.MediumEditorTable = factory;
   }


### PR DESCRIPTION
The plugin doesn't load when I use it with RequireJS. Dependent module receives undefined instead of plugin constructor.
To fix it, the plugin function should be defined through defining function.

``` javascript
} else if (typeof define === 'function' && define.amd) {
  // define(factory); - RequireJS will think that factory defines something
  define(function () { return factory}); // instead we use a wrapper, that will return our factory.
```

This works and tested. You can see the same approach in Medium-Editor itself.
https://github.com/yabwe/medium-editor/blob/master/dist/js/medium-editor.js#L391
